### PR TITLE
Convert batch parameters to uppercase

### DIFF
--- a/includes/cf/mailchimp.cfc
+++ b/includes/cf/mailchimp.cfc
@@ -48,11 +48,11 @@
 			<cfhttpparam name="replaceInterests" value="#arguments.replaceGroups#" type="url">
 		
 			<cfloop query="arguments.subscribers">
-				<cfhttpparam name="batch[#currentrow#][email]" value="#arguments.subscribers.e#" type="url">
-				<cfhttpparam name="batch[#currentrow#][email_type]" value="html" type="url">
-				<cfhttpparam name="batch[#currentrow#][fname]" value="#arguments.subscribers.f#" type="url">
-				<cfhttpparam name="batch[#currentrow#][lname]" value="#arguments.subscribers.l#" type="url">
-				<cfhttpparam name="batch[#currentrow#][interests]" value="#arguments.subscribers.g#" type="url">
+				<cfhttpparam name="batch[#currentrow#][EMAIL]" value="#arguments.subscribers.e#" type="url">
+				<cfhttpparam name="batch[#currentrow#][EMAIL_TYPE]" value="html" type="url">
+				<cfhttpparam name="batch[#currentrow#][FNAME]" value="#arguments.subscribers.f#" type="url">
+				<cfhttpparam name="batch[#currentrow#][LNAME]" value="#arguments.subscribers.l#" type="url">
+				<cfhttpparam name="batch[#currentrow#][INTERESTS]" value="#arguments.subscribers.g#" type="url">
 			</cfloop>
 		</cfhttp>
 		


### PR DESCRIPTION
**listBatchSubscribe** throws an 'Invalid Email Address' error when using the lowercase 'email' batch parameter. [Documentation for v1.3 API](http://apidocs.mailchimp.com/api/1.3/listbatchsubscribe.func.php) suggests using the uppercase key name 'EMAIL' . 
For consistency, I've updated the other 4 parameters, although it isn't necessary.
