### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/includes/cf/mailchimp.cfc
+++ b/includes/cf/mailchimp.cfc
@@ -9,16 +9,16 @@
 	<cffunction name="init" access="public" returntype="Any">
 		<cfargument name="apikey" required="true">
 		<cfargument name="output" required="false" default="json" type="string">
-		
+
 		<cfscript>
 			this.options.apikey = arguments.apikey;
 			this.options.output = arguments.output;
 			this.options.serviceURL = "http://#ListLast(this.options.apikey,"-")#.api.mailchimp.com/1.3/";
-		</cfscript>			
+		</cfscript>
 		<cfreturn this />
 	</cffunction>
 
-	<!-- 
+	<!--
 		[listBatchSubscribe]
 		Subscribe a batch of email addresses to a list at once.
 		[Required]
@@ -37,7 +37,7 @@
 		<cfargument name="updateExisting" required="false" type="boolean" default="1">
 		<cfargument name="replaceGroups" required="false" type="boolean" default="0">
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
-			
+
 		<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listBatchSubscribe" type="url">
@@ -46,7 +46,7 @@
 			<cfhttpparam name="double_optin" value="#arguments.sendOptInConfirm#" type="url">
 			<cfhttpparam name="update_existing" value="#arguments.updateExisting#" type="url">
 			<cfhttpparam name="replaceInterests" value="#arguments.replaceGroups#" type="url">
-		
+
 			<cfloop query="arguments.subscribers">
 				<cfhttpparam name="batch[#currentrow#][EMAIL]" value="#arguments.subscribers.e#" type="url">
 				<cfhttpparam name="batch[#currentrow#][EMAIL_TYPE]" value="html" type="url">
@@ -55,20 +55,20 @@
 				<cfhttpparam name="batch[#currentrow#][INTERESTS]" value="#arguments.subscribers.g#" type="url">
 			</cfloop>
 		</cfhttp>
-		
+
 		<cfscript>
 			return decodeOutput(arguments.output,cfhttp.filecontent);
 		</cfscript>
 	</cffunction>
 
-	<!-- 
+	<!--
 		[listBatchUnsubscribe]
 		Unsubscribe a batch of email addresses from a list at once.
 		Parameters:
 			[Required]
 			(string) id : ID of the list to list groupings for
 			(query) subscribers : list of all subscribers (email, fname, lname, and interests)
-			
+
 			[Optional]
 			(string) output : Type of output desired [ xml | json ]
 			(bool) sendOptInConfirm : Send confirmation emails to the users being subscribed.
@@ -83,7 +83,7 @@
 		<cfargument name="delete_member" required="false" type="boolean" default="0">
 		<cfargument name="send_goodbye" required="false" type="boolean" default="1">
 		<cfargument name="send_notify" required="false" type="boolean" default="0">
-			
+
 		<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listBatchUnsubscribe" type="URL">
@@ -92,18 +92,18 @@
 			<cfhttpparam name="delete_member" value="#arguments.delete_member#" type="url">
 			<cfhttpparam name="send_goodbye" value="#arguments.send_goodbye#" type="url">
 			<cfhttpparam name="send_notify" value="#arguments.send_notify#" type="url">
-		
+
 			<cfloop query="arguments.subscribers">
 				<cfhttpparam name="emails[#currentrow#]" value="#email#" type="url">
 			</cfloop>
 		</cfhttp>
-		
+
 		<cfscript>
 			return decodeOutput(arguments.output,cfhttp.filecontent);
-		</cfscript>	
+		</cfscript>
 	</cffunction>
 
-	<!-- 
+	<!--
 		[listSubscribe]
 		Subscribe a user to a certain list.
 		Parameters:
@@ -113,7 +113,7 @@
 			(string) firstname : First name of subscriber
 			(string) lastname : Last name of subscriber
 			(struct) lists : Structure of the lists the member should be subscribed to
-			
+
 			[Optional]
 			(string) output : Type of output desired [ xml | json ]
 			(boolean) double_optin : Send a double opt-in email?
@@ -131,7 +131,7 @@
 		<cfargument name="update_existing" required="false" type="boolean" default="1">
 		<cfargument name="replace_interests" required="false" type="boolean" default="1">
 		<cfargument name="send_welcome" required="false" type="boolean" default="0">
-	
+
 	 	<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listSubscribe" type="url">
@@ -153,15 +153,15 @@
 				<cfhttpparam name="merge_vars[GROUPINGS][#count#][groups]" value="#arguments.lists[groupItem]["groups"]#" type="url">
 				<cfset count = count + 1 />
 			</cfloop>
-		</cfhttp>	
-	
+		</cfhttp>
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
 		</cfscript>
 	</cffunction>
-	
-	<!-- 
+
+	<!--
 		[listUnsubscribe]
 		Retrieve all of the lists defined for the user account associated with the api key.
 		Parameters:
@@ -181,7 +181,7 @@
 		<cfargument name="delete" required="false" type="boolean" default="0">
 		<cfargument name="goodbye" required="false" type="boolean" default="1">
 		<cfargument name="notify" required="false" type="boolean" default="1">
-	
+
 	 	<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="method" value="listUnsubscribe" type="url">
 			<cfhttpparam name="apikey" value="#this.options.apikey#" type="url">
@@ -190,15 +190,15 @@
 			<cfhttpparam name="delete_member" value="#arguments.delete#" type="url">
 			<cfhttpparam name="send_goodbye" value="#arguments.goodbye#" type="url">
 			<cfhttpparam name="send_notify" value="#arguments.notify#" type="url">
-		</cfhttp>	
-	
+		</cfhttp>
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
 		</cfscript>
 	</cffunction>
 
-	<!-- 
+	<!--
 		[lists]
 		Retrieve all of the lists defined for the user account associated with the api key.
 		Parameters:
@@ -207,13 +207,13 @@
 	-->
 	<cffunction name="lists" access="public" returntype="any" hint="I get a list of lists, as query">
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
-		
+
 	 	<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="lists" type="url">
 			<cfhttpparam name="apikey" value="#this.options.apikey#" type="url">
-		</cfhttp>	
-	
+		</cfhttp>
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
@@ -232,18 +232,18 @@
 	<cffunction name="listInterestGroupings" access="public" Returntype="Any" hint="I find all groupings of a list.">
 		<cfargument name="id" required="true" type="string">
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
-	
+
 		<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listInterestGroupings" type="url">
 			<cfhttpparam name="apikey" value="#this.options.apikey#" type="url">
 			<cfhttpparam name="id" value="#arguments.id#" type="url">
 		</cfhttp>
-		 
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
-		</cfscript>	
+		</cfscript>
 	</cffunction>
 
 	<!--
@@ -262,7 +262,7 @@
 		<cfargument name="group_name" required="true" type="string">
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
 		<cfargument name="grouping_id" required="false" type="string">
-	
+
 		<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listInterestGroupAdd" type="url">
@@ -273,7 +273,7 @@
 				<cfhttpparam name="grouping_id" value="#arguments.grouping_id#" type="url">
 			</cfif>
 		</cfhttp>
-		 
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
@@ -297,7 +297,7 @@
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
 		<cfargument name="grouping_id" required="false" type="string">
 
-	
+
 		<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listInterestGroupDel" type="url">
@@ -308,13 +308,13 @@
 				<cfhttpparam name="grouping_id" value="#arguments.grouping_id#" type="url">
 			</cfif>
 		</cfhttp>
-		 
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
-		</cfscript>	
+		</cfscript>
 	</cffunction>
-	
+
 	<!--
 		[listInterestGroupUpdate]
 		Change the name of an Interest Group
@@ -334,7 +334,7 @@
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
 		<cfargument name="grouping_id" required="false" type="string">
 
-	
+
 		<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listInterestGroupUpdate" type="url">
@@ -346,14 +346,14 @@
 				<cfhttpparam name="grouping_id" value="#arguments.grouping_id#" type="url">
 			</cfif>
 		</cfhttp>
-		 
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
-		</cfscript>	
+		</cfscript>
 	</cffunction>
-	
-	<!-- 
+
+	<!--
 		[listMembers]
 		Get all of the list members for a list that are of a particular status.
 		Parameters:
@@ -370,7 +370,7 @@
 		<cfargument name="limit" required="false" type="numeric" default="5000">
 		<cfargument name="since" required="false" type="date">
 		<cfargument name="start" required="false" type="numeric">
-		
+
 	 	<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listMembers" type="url">
@@ -378,21 +378,21 @@
 			<cfhttpparam name="id" value="#arguments.id#" type="url">
 			<cfhttpparam name="status" value="#arguments.status#" type="url">
 			<cfhttpparam name="limit" value="#arguments.limit#" type="url">
-		</cfhttp>	
-	
+		</cfhttp>
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
 		</cfscript>
-	</cffunction>	
-	
-	<!-- 
+	</cffunction>
+
+	<!--
 		[listMemberInfo]
 		Get all the information for particular members of a list.
 		Parameters:
 			[Required]
 			(string) id : ID of the list to query.
-			(string) email : Email of the use to query for.				
+			(string) email : Email of the use to query for.
 			[Optional]
 			(string) output : Type of output desired [ xml | json ]
 	-->
@@ -400,21 +400,21 @@
 		<cfargument name="id" required="true" type="string">
 		<cfargument name="email" required="true" type="string">
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
-		
+
 	 	<cfhttp url="#this.options.serviceURL#" method="post">
 			<cfhttpparam name="output" value="#arguments.output#" type="url">
 			<cfhttpparam name="method" value="listMemberInfo" type="url">
 			<cfhttpparam name="apikey" value="#this.options.apikey#" type="url">
 			<cfhttpparam name="id" value="#arguments.id#" type="url">
 			<cfhttpparam name="email_address" value="#arguments.email#" type="url">
-		</cfhttp>	
-	
+		</cfhttp>
+
 		<cfscript>
 			if(StructKeyExists(cfhttp,"errorDetail") && cfhttp.errorDetail != "") return returnError(cfhttp);
 			else return decodeOutput(arguments.output,cfhttp.filecontent);
 		</cfscript>
-	</cffunction>	
-	
+	</cffunction>
+
 	<!--
 		UTILITY
 	-->
@@ -450,7 +450,7 @@
 			returnStruct["error"] = StructNew();
 			returnStruct["error"]["statusCode"] = arguments.http.statusCode;
 			returnStruct["error"]["errorDetail"] = arguments.http.errorDetail;
-			
+
 			return returnStruct;
 		</cfscript>
 	</cffunction>


### PR DESCRIPTION
Trailing whitespaces lead to false diffs, therefore they should be trimmed on save.

In **Eclipse**, this can be done by going to Preferences -> ColdFusion -> Profiles -> Editor and check

```
[x] Trim spaces before saving file
```

In **Sublime Text 2**,  just open Preferences -> Settings - User and set 

``` javascript
"trim_trailing_white_space_on_save": true
```

_If you don't want to change the way the project works, feel free to close this._
