### PR TITLE
Validate response data format

### DIFF
--- a/includes/cf/mailchimp.cfc
+++ b/includes/cf/mailchimp.cfc
@@ -431,8 +431,9 @@
 		<cfargument name="data" required="true" type="any">
 
 		<cfscript>
-			if(LCase(arguments.output) == "json") return DeserializeJSON(arguments.data);
-			else if(LCase(arguments.output) == "xml") return xmlParse(arguments.data);
+			if(LCase(arguments.output) == "json" && isJSON(arguments.data)) return DeserializeJSON(arguments.data);
+			else if(LCase(arguments.output) == "xml" && isXML(arguments.data)) return xmlParse(arguments.data);
+			return htmlEditFormat(arguments.data);
 		</cfscript>
 	</cffunction>
 


### PR DESCRIPTION
If the API returned data format is neither JSON nor XML, ColdFusion will throw data parsing errors when failing to convert the JSON string or XML document. To prevent that, I've added validation rules for both formats and returned the HTML-escaped response string.

This shouldn't happen very often, but it's good to have it as a safety net against API downtimes or server rejects (like previously resolved 'HTTP 414 Request-URI Too Large').
