### PR TITLE
Remove apikey argument from listBatchUnsubscribe

### DIFF
--- a/includes/cf/mailchimp.cfc
+++ b/includes/cf/mailchimp.cfc
@@ -77,7 +77,6 @@
 	-->
 	<cffunction name="listBatchUnsubscribe" access="public" Returntype="Any">
 		<cfargument name="output" required="false" type="string" default="#this.options.output#">
-		<cfargument name="apikey" required="true" type="string">
 		<cfargument name="id" required="true" type="string">
 		<cfargument name="subscribers" required="true" type="query">
 		<cfargument name="delete_member" required="false" type="boolean" default="0">


### PR DESCRIPTION
There's no need to create a parameter definition for **apikey** within _listBatchUnsubscribe_ since we get it from the **options** object when building the HTTP request.
